### PR TITLE
move nomad executable to /usr/local/bin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ apt-get -y install curl unzip iptables iproute2 && \
         curl -o nomad.zip https://releases.hashicorp.com/nomad/${nomad_version}/nomad_${nomad_version}_linux_amd64.zip && \
         unzip nomad.zip && \
         rm nomad.zip && \
+        mv nomad /usr/local/bin && \
         curl -L -o cni-plugins.tgz https://github.com/containernetworking/plugins/releases/download/v${cni_version}/cni-plugins-linux-amd64-v${cni_version}.tgz && \
         mkdir -p /usr/libexec/cni && \
         tar -xvzf cni-plugins.tgz -C /usr/libexec/cni && \
@@ -16,4 +17,4 @@ apt-get -y install curl unzip iptables iproute2 && \
         rm -rf /var/cache/apt
 
 LABEL org.opencontainers.image.source https://github.com/resinstack/nomad
-ENTRYPOINT ["/nomad"]
+ENTRYPOINT ["/usr/local/bin/nomad"]

--- a/Dockerfile.source
+++ b/Dockerfile.source
@@ -15,7 +15,7 @@ for p in ${nomad_prs} ; do curl -L ${nomad_origin}/pull/$p.patch | git am - ; do
 FROM debian:buster-slim
 ARG cni_version=0.9.0
 WORKDIR /
-COPY --from=build /nomad /nomad
+COPY --from=build /nomad /usr/local/bin/nomad
 RUN apt-get update && \
         apt-get -y install curl unzip iptables iproute2 && \
         curl -L -o cni-plugins.tgz https://github.com/containernetworking/plugins/releases/download/v${cni_version}/cni-plugins-linux-amd64-v${cni_version}.tgz && \
@@ -27,4 +27,4 @@ RUN apt-get update && \
         rm -rf /var/cache/apt
 
 LABEL org.opencontainers.image.source https://github.com/resinstack/nomad
-ENTRYPOINT ["/nomad"]
+ENTRYPOINT ["/usr/local/bin/nomad"]


### PR DESCRIPTION
This pr moves the `nomad` executable into a directory accessible from `PATH` (`/usr/local/bin/`). This is useful for ci jobs that override the docker entrypoint to `/bin/bash` and previously needed to specify the absolute path.